### PR TITLE
Minimal feature to connect to WP RAG API

### DIFF
--- a/endpoints/dify-wp-rag.py
+++ b/endpoints/dify-wp-rag.py
@@ -1,4 +1,6 @@
 import time
+import json
+import requests
 from typing import Mapping
 from werkzeug import Request, Response
 from dify_plugin import Endpoint
@@ -9,9 +11,38 @@ class DifyWpRagEndpoint(Endpoint):
         """
         Invokes the endpoint with the given request.
         """
-        def generator():
-            for i in range(10):
-                time.sleep(1)
-                yield f"{i} <br>"
+        # Parse JSON from the incoming request
+        body = r.json
 
-        return Response(generator(), status=200, content_type="text/html")
+        pipeline_id = body.get("knowledge_id")
+        query = body.get("query")
+
+        # Extract retrieval settings with sensible defaults
+        retrieval_settings = body.get("retrieval_setting")
+        top_k = retrieval_settings.get("top_k")
+        score_threshold = retrieval_settings.get("score_threshold")
+
+        site_id = settings.get("wp_rag_site_id")
+        api_key = settings.get("wp_rag_api_key")
+
+        base_url = 'https://wp-rag.mobalab.net'
+        url = base_url + '/api/sites/' + site_id + '/posts/search'
+        # Note that top_k and score_threshold are ignored at this moment.
+        params = {'q': query, 'top_k': top_k, 'score_threshold': score_threshold}
+        headers = {'Content-Type': 'application/json', 'X-Api-Key': api_key}
+
+        response = requests.get(url, params, headers=headers)
+        results = []
+        for record in response.json()['search_results']:
+            result = {
+                "metadata": {
+                    "path": record['url'],
+                    "description": ''
+                },
+                "score": 0.8, #TODO Not implemented on the API side
+                "title": record['title'],
+                "content": record['body']
+            }
+            results.append(result)
+
+        return Response(json.dumps({"records": results}), status=200, content_type="application/json")

--- a/endpoints/dify-wp-rag.py
+++ b/endpoints/dify-wp-rag.py
@@ -27,8 +27,7 @@ class DifyWpRagEndpoint(Endpoint):
 
         base_url = 'https://wp-rag.mobalab.net'
         url = base_url + '/api/sites/' + site_id + '/posts/search'
-        # Note that top_k and score_threshold are ignored at this moment.
-        params = {'q': query, 'top_k': top_k, 'score_threshold': score_threshold}
+        params = {'q': query, 'limit': top_k, 'score_threshold': score_threshold}
         headers = {'Content-Type': 'application/json', 'X-Api-Key': api_key}
 
         response = requests.get(url, params, headers=headers)
@@ -36,12 +35,12 @@ class DifyWpRagEndpoint(Endpoint):
         for record in response.json()['search_results']:
             result = {
                 "metadata": {
-                    "path": record['url'],
+                    "path": record['post']['url'],
                     "description": ''
                 },
-                "score": 0.8, #TODO Not implemented on the API side
-                "title": record['title'],
-                "content": record['body']
+                "score": record['score'],
+                "title": record['post']['title'],
+                "content": record['post']['content']
             }
             results.append(result)
 

--- a/endpoints/dify-wp-rag.yaml
+++ b/endpoints/dify-wp-rag.yaml
@@ -1,5 +1,5 @@
-path: "/uwu/dify-wp-rag/uwu"
-method: "GET"
+path: "/retrieval"
+method: "POST"
 extra:
   python:
     source: "endpoints/dify-wp-rag.py"

--- a/group/dify-wp-rag.yaml
+++ b/group/dify-wp-rag.yaml
@@ -1,14 +1,25 @@
 settings:
-  - name: api_key
+  - name: wp_rag_site_id
+    type: text-input
+    required: true
+    label:
+      en_US: Site ID on WP RAG
+      zh_Hans: Site ID on WP RAG
+      pt_BR: Site ID on WP RAG
+    placeholder:
+      en_US: Please input the site ID on WP RAG
+      zh_Hans: 请输入你的 the site ID on WP RAG
+      pt_BR: Please input the site ID on WP RAG
+  - name: wp_rag_api_key
     type: secret-input
     required: true
     label:
-      en_US: API key
-      zh_Hans: API key
-      pt_BR: API key
+      en_US: WP RAG API key
+      zh_Hans: WP RAG API key
+      pt_BR: WP RAG API key
     placeholder:
-      en_US: Please input your API key
-      zh_Hans: 请输入你的 API key
-      pt_BR: Please input your API key
+      en_US: Please input your WP RAG API key
+      zh_Hans: 请输入你的 WP RAG API key
+      pt_BR: Please input your WP RAG API key
 endpoints:
   - endpoints/dify-wp-rag.yaml

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -34,7 +34,7 @@ resource:
       enabled: false
     storage:
       enabled: false
-      size: 0
+      size: 1024
 plugins:
   endpoints:
     - group/dify-wp-rag.yaml

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -3,10 +3,10 @@ type: plugin
 author: k4200
 name: dify-wp-rag
 label:
-  en_US: dify-wp-rag
-  ja_JP: dify-wp-rag
-  zh_Hans: dify-wp-rag
-  pt_BR: dify-wp-rag
+  en_US: WP RAG
+  ja_JP: WP RAG
+  zh_Hans: WP RAG
+  pt_BR: WP RAG
 description:
   en_US: Extension that connects to WP RAG API server
   ja_JP: Extension that connects to WP RAG API server


### PR DESCRIPTION
## What I did

Implemented a minimal feature of a Dify's extension plugin. It can connect to WP RAG API, and retrieve WordPress posts similar to the input query string.

## How to test the feature

~~Note that the necessary endpoint hasn't been deployed to production of WP RAG API. It will be ready in a week or so.~~

* Execute Dify on a local machine: [Deploy with Docker Compose - Dify Docs](https://docs.dify.ai/en/getting-started/install-self-hosted/docker-compose)
* On the plugin page, click on the bug icon, and copy and paste the URL and Key to `.env` of this plugin.
    * <img width="267" alt="image" src="https://github.com/user-attachments/assets/32b3f684-def9-4fb9-813e-073040697102" />
    * Note that the key changes every few hours or so.
* Execute `python -m main` to install this plugin. This will add a panel that looks like the following to the plugin page:
    * <img width="683" alt="image" src="https://github.com/user-attachments/assets/4af5bd09-24c0-44c8-8183-480210fd5aa9" />
* Click on the plugin icon, and add an endpoint:
    * <img width="429" alt="image" src="https://github.com/user-attachments/assets/06e61f2b-24d6-498b-b1e9-103664ccde41" />
    * `Endpoint Name`: Arbitrary name
    * `Site ID on WP RAG` and `WP RAG API key`: Currently, invisible on WP RAG plugin's UI. You can see them on the WordPress database by executing `select * from wp_options where option_name = 'wp_rag_auth_data'`
* Copy the endpoint URL, which looks like `http://localhost/e/y64nt432xlp5p0g1/retrieval`, and remove the trailing `/retrieval`
* On the "Knowledge" section, "Add an External Knowledge API":
    * <img width="484" alt="image" src="https://github.com/user-attachments/assets/fa6d0174-efc9-4802-a4f0-57c213052e7f" />
    * `Name`: Arbitrary name
    * `API Endpoint`: the copied URL in the previous step, and replace the host name with `nginx`. e.g. `http://nginx/e/y64nt432xlp5p0g1`
    * `API Key`: This is not used, so put any string.
* "Connect to an External Knowledge Base":
    * <img width="706" alt="image" src="https://github.com/user-attachments/assets/003c26c6-f4a4-4ca9-aa91-6e673b1b37dd" />
    * `External Knowledge Name`: Arbitrary name
    * `Knowledge Description`: This is optional, so leave it blank.
    * `External Knowledge API`: Choose the one that you created in the previous step.
    * `External Knowledge ID`: This isn't used, so put any number here.
    * `Retrieval Setting`: Leave them as-is for now.
* Once the external knowledge is created, you can do "Retrieval Test".
